### PR TITLE
Adiciona sub-subdomínios de blogs UOL

### DIFF
--- a/webext/manifest.json
+++ b/webext/manifest.json
@@ -67,6 +67,7 @@
     "*://super.abril.com.br/*",
     "*://veja.abril.com.br/*",
     "*://*.uol.com.br/*",
+    "*://*.blogosfera.uol.com.br/*",
     "*://www.uol/*"
   ],
 


### PR DESCRIPTION
Resolve #69 

Da [documentação](https://developer.chrome.com/apps/match_patterns)
> If the host is *.hostname, then it matches the specified host or any of its subdomains.

E não falam nada sobre sub-subdomínios. O userscript não tem esse problema.