### PR TITLE
Adiciona suporte ao Gazeta Online

### DIFF
--- a/webext/background.js
+++ b/webext/background.js
@@ -54,6 +54,12 @@ const BLOCKLIST = {
       '*://www.netdeal.com.br/*',
     ]
   },
+  gazetaonline: {
+    cookieBlocking: {
+      urlFilter: '*://www.gazetaonline.com.br/*',
+      blockAll: true
+    }
+  },
   gauchazh: {
     scriptBlocking: [
       '*://gauchazh.clicrbs.com.br/static/main*',

--- a/webext/manifest.json
+++ b/webext/manifest.json
@@ -81,7 +81,8 @@
     "*://www.uol/*",
     "*://*.gramophone.co.uk/*",
     "*://www.folhadelondrina.com.br/*/fivewall.js*",
-    "*://pioneiro.clicrbs.com.br/*"
+    "*://pioneiro.clicrbs.com.br/*",
+    "*://www.gazetaonline.com.br/*"
   ],
 
   "applications": {

--- a/webext/options.html
+++ b/webext/options.html
@@ -75,6 +75,12 @@
             </div>
             <div>
                 <label>
+                    <input type="checkbox" id="gazetaonline" checked>
+                    <span>Gazeta Online</span>
+                </label>
+            </div>
+            <div>
+                <label>
                     <input type="checkbox" id="gauchazh" checked>
                     <span>GaúchaZH</span>
                 </label>

--- a/webext/options.js
+++ b/webext/options.js
@@ -7,6 +7,7 @@ const SITES = [
   'folhadespaulo',
   'foreignpolicy',
   'gazetadopovo',
+  'gazetaonline',
   'gauchazh',
   'gramophone',
   'jornaldesantacatarina',


### PR DESCRIPTION
O paywall do Gazeta Online é gerado no lado do servidor, portanto, notícias exclusivas para assinantes até o momento não são burláveis. 