### PR TITLE
Corrige JOTA

### DIFF
--- a/userscript/burlesco.user.js
+++ b/userscript/burlesco.user.js
@@ -24,7 +24,7 @@
 // @match        *://*.gazetadopovo.com.br/*
 // @match        *://assets.imirante.com/*
 // @match        *://ogjs.infoglobo.com.br/*
-// @match        *://jota.info/*
+// @match        *://*.jota.info/*
 // @match        *://jornaldesantacatarina.clicrbs.com.br/*
 // @match        *://www.jornalnh.com.br/*
 // @match        *://*.nexojornal.com.br/*
@@ -68,6 +68,7 @@
 // @webRequestItem {"selector":"http://jornaldesantacatarina.clicrbs.com.br/jornal/jsp/paywall*","action":"cancel"}
 // @webRequestItem {"selector":"*://*.estadao.com.br/paywall/*","action":"cancel"}
 // @webRequestItem {"selector":"*://www.folhadelondrina.com.br/*/fivewall.js*","action":"cancel"}
+// @webRequestItem {"selector":"*://*.jota.info/wp-content/themes/JOTA/assets/js/posts.js*","action":"cancel"}
 // @run-at       document-start
 // @noframes
 // ==/UserScript==
@@ -112,7 +113,7 @@ if (/gauchazh\.clicrbs\.com\.br/.test(document.location.host)) {
 }
 
 else if (/jota\.info/.test(document.location.host)) {
-  document.cookie = 'articles=null;path=/';
+  document.getElementsByClassName('jota-paywall')[0].remove();
 }
 
 

--- a/webext/background.js
+++ b/webext/background.js
@@ -79,13 +79,9 @@ const BLOCKLIST = {
     ]
   },
   jota: {
-    cookieBlocking: {
-      urlFilter: 'http://jota.info/*',
-      cookie: {
-        url: 'http://jota.info/*',
-        name: 'articles'
-      }
-    }
+    scriptBlocking: [
+      '*://*.jota.info/wp-content/themes/JOTA/assets/js/posts.js*'
+    ]
   },
   medium: {
     cookieBlocking: {

--- a/webext/content.js
+++ b/webext/content.js
@@ -67,6 +67,12 @@ const INJECTION = {
       localStorage.clear();
       sessionStorage.clear();
     `
+  },
+  jota: {
+    url: /jota.info/,
+    code: `
+      document.getElementsByClassName('jota-paywall')[0].remove();
+    `
   }
 };
 

--- a/webext/manifest.json
+++ b/webext/manifest.json
@@ -29,7 +29,8 @@
         "*://super.abril.com.br/*",
         "*://*.veja.abril.com.br/*",
         "*://*.wsj.com/*",
-        "*://*.medium.com/*"
+        "*://*.medium.com/*",
+        "*://*.jota.info/*"
       ]
     },
     {
@@ -60,7 +61,7 @@
     "*://*.gazetadopovo.com.br/*",
     "*://assets.imirante.com/*",
     "*://*.infoglobo.com.br/*",
-    "*://jota.info/*",
+    "*://*.jota.info/*",
     "*://jornaldesantacatarina.clicrbs.com.br/*",
     "*://www.jornalnh.com.br/*",
     "*://*.nexojornal.com.br/*",


### PR DESCRIPTION
Após algumas horas pesquisando e descobrir vários métodos para furar o paywall do JOTA, o mais fácil e simples foi este. O único lado negativo é que os botões Aa (aqueles que aumentam e diminuem a letra do artigo) não funcionam já que estão no mesmo script, de acordo com os meus testes é tudo.   
  
Existem mais dois métodos que podem furar o paywall:  
1. Método de injeção do Augusto no script *://*.jota.info/wp-content/themes/JOTA/assets/js/posts.js*;
2. Apagar o elemento do paywall e deixar um timer aplicando o body.style.overflow="scroll" já que o script acima tem um timer que oculta o scroll da página quando o paywall é ativado, a única coisa que não gostei desse método é que a barrinha de scroll pisca, ainda que uma única vez e por milésimos e por este motivo procurei um método mais 'silencioso'.   
  
  
Resolve #125 