### PR TITLE
Corrige UOL Mídia Global

### DIFF
--- a/webext/background.js
+++ b/webext/background.js
@@ -162,7 +162,12 @@ const BLOCKLIST = {
   uol: {
     scriptBlocking: [
       '*://tm.jsuol.com.br/modules/content-gate.js',
-    ]
+    ],
+    headerInjection: {
+      name: 'User-Agent',
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25',
+      urlFilter: '*://noticias.uol.com.br/midiaglobal/nytimes/*'
+    }
   },
   veja: {
     scriptBlocking: [


### PR DESCRIPTION
Resolve #83   
  
Limitação: Por enviar um User-Agent Mobile, ele retorna apenas a página para mobile portanto alguém que acesse pelo Desktop receberá uma versão mobile da página, limitei o User-Agent apenas para o pattern *://noticias.uol.com.br/midiaglobal/nytimes/* de forma que o restante do site não seja afetado, já que de acordo com os meus testes apenas a parte /midiaglobal/nytimes/ tem o paywall.  
  
Uma possibilidade mais complexa é baixar a notícia via JS e injetar no DOM da página.